### PR TITLE
fix: stop redirecting to /setup when embedding is still generating

### DIFF
--- a/frontend/src/pages/ArtistFeed.jsx
+++ b/frontend/src/pages/ArtistFeed.jsx
@@ -39,12 +39,13 @@ export default function ArtistFeed() {
     })
       .then(res => {
         if (res.status === 409) {
-          if (retryCount.current < 5) {
+          if (retryCount.current < 10) {
             retryCount.current += 1
             setWarming(true)
-            setTimeout(() => loadGigs(true), 2000)
+            setTimeout(() => loadGigs(true), 3000)
           } else {
-            navigate('/setup', { replace: true })
+            setWarming(false)
+            setError('Your profile is still being processed. Check back in a minute.')
           }
           return null
         }


### PR DESCRIPTION
## Summary
- Increased retries from 5 to 10 and wait time from 2s to 3s (30 seconds total)
- Instead of bouncing user back to /setup after max retries, show a friendly message
- Root cause: embedding generates in background after profile save, feed was kicking users out before it finished

## Test plan
- [ ] Create new account, fill profile, hit save
- [ ] Should land on artist feed with spinner, not redirect back to /setup
- [ ] After embedding generates, matches should appear